### PR TITLE
skip quoting ':' to fix the errors related to invalid parameter results

### DIFF
--- a/monitis/monitors/custom_impl.py
+++ b/monitis/monitors/custom_impl.py
@@ -404,7 +404,7 @@ class CustomMonitor(Monitis):
         for name, value in results_items:
             # urllib.quote each to implement "double encoding"
             # http://monitis.com/api/api.html#api_home
-            result_strings.append(quote(':'.join((name, str(value)))))
+            result_strings.append(quote(':'.join((name, str(value))),':'))
         
         result_string =  self.post(action=action, monitorId=self.monitor_id,
                          checktime=result_checktime,


### PR DESCRIPTION
Hi.

I will get following errors if we don't skip to quoting ':' in results item.

{u'error': u'Invalid parameter results. Valid format is: paramName1:paramValue1[;paramName2:paramValue2...] '}

Could you help to check it ?

Thanks,
Jeffery 
